### PR TITLE
Helper method for fixing incorrect order

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ const tree = [
 ];
 ```
 
-If there's a `parent` relation, the children must follow their parent right after it.
+If there's a `parent` relation, the children must follow their parent right after it (you might use `fixOrder` helper function if your data does not meet that criteria).
 
 > You can find suggested default styling for the package at `style.css` in the package root.
 
@@ -126,6 +126,13 @@ Allows moving tree rows while `retain`ing given fields at their original rows. Y
 Makes it possible to toggle node children through a user interface.
 
 > This depends on [resolve.index](https://www.npmjs.com/package/table-resolver#resolveindex)!
+
+### Helpers
+
+**`tree.fixOrder = ({ parentField = 'parent', idField = 'id' }) => (rows) => [<rows in correct order>]`**
+
+If children in your rows don't follow their parents you can use that helper method so they will be moved into right place. 
+Basically it converts `[ parent, x, y, z, children ]` into `[ parent, children, x, y, z ]`.
 
 ## Example
 

--- a/__tests__/fix-order-test.js
+++ b/__tests__/fix-order-test.js
@@ -1,0 +1,532 @@
+import { fixOrder } from '../src';
+
+import { cloneDeep, reverse } from 'lodash';
+
+describe('fixOrder', () => {
+
+  it('works with empty array', () => {
+    expect(fixOrder()([])).toEqual([]);
+  });
+
+  it('works with null', () => {
+    expect(fixOrder()(null)).toEqual(null);
+  });
+
+  it('works with rows with no children', () => {
+    const dummyRows = [
+      {
+        name: 'A',
+        id:1
+      },
+      {
+        name: 'B',
+        id: 2
+      }
+    ];
+
+    expect(fixOrder()(dummyRows)).toEqual(dummyRows);
+  });
+
+  it ('works with rows with children in right order', () => {
+    const dummyRows = [
+      {
+        name: 'parent',
+        id: 13
+      },
+      {
+        name: 'children',
+        parent: 13
+      },
+      {
+        name: 'another one'
+      }
+    ];
+
+    expect(fixOrder()(dummyRows)).toEqual(dummyRows);
+  });
+
+  it ('works with simple case of wrong order', () => {
+    const rowsWithWrongOrder = [
+      {
+        name: 'parent',
+        id: 13
+      },
+      {
+        name: 'another one'
+      },
+      {
+        name: 'children',
+        parent: 13
+      }
+    ];
+
+    const expectedRows = [
+      {
+        name: 'parent',
+        id: 13
+      },
+      {
+        name: 'children',
+        parent: 13
+      },
+      {
+        name: 'another one'
+      }
+    ];
+
+    expect(fixOrder()(rowsWithWrongOrder)).toEqual(expectedRows);
+  });
+
+
+  it ('works when id is equal to zero', () => {
+    const rowsWithWrongOrder = [
+      {
+        name: 'parent',
+        id: 0
+      },
+      {
+        name: 'another one'
+      },
+      {
+        name: 'another one2'
+      },
+      {
+        name: 'children',
+        parent: 0
+      }
+    ];
+
+    const expectedRows = [
+      {
+        name: 'parent',
+        id: 0
+      },
+      {
+        name: 'children',
+        parent: 0
+      },
+      {
+        name: 'another one'
+      },
+      {
+        name: 'another one2'
+      },
+    ];
+
+    expect(fixOrder()(rowsWithWrongOrder)).toEqual(expectedRows);
+  });
+
+  it ('works when parent is set to null', () => {
+    const rowsWithNullParent = [
+      {
+        name: 'something'
+      },
+      {
+        id: 0
+      },
+      {
+        name: 'invalid element',
+        parent: null
+      },
+      {
+        parent: 0
+      },
+      {
+        name: 'valid element'
+      }
+    ];
+
+    const expected = [
+      {
+        name: 'something'
+      },
+      {
+        id: 0
+      },
+      {
+        parent: 0
+      },
+      {
+        name: 'invalid element',
+        parent: null
+      },
+      {
+        name: 'valid element'
+      }
+    ];
+
+    expect(fixOrder()(rowsWithNullParent)).toEqual(expected);
+  });
+
+  it ('works when id set to null', () => {
+    const rowsWithIdNull = [
+      {
+        id: null
+      },
+      {
+        name: 'something'
+      },
+      {
+        id: 5
+      }
+    ];
+
+    expect(fixOrder()(rowsWithIdNull)).toEqual(rowsWithIdNull);
+  });
+
+  it ('works when parent id points to non existing element', () => {
+    const rowsWithInvalidParentId = [
+      {
+        id: 2
+      },
+      {
+        name: 'something'
+      },
+      {
+        parent: 1
+      }
+    ];
+    expect(fixOrder()(rowsWithInvalidParentId)).toEqual(rowsWithInvalidParentId);
+  });
+
+  it ('works with multiple parents', () => {
+    const rowsWithMultipleParents = [
+      {
+        name: 'parent1',
+        id: 13
+      },
+      {
+        name: 'something else',
+        id: 1
+      },
+      {
+        name: 'children1-1',
+        parent: 13
+      },
+      {
+        name: 'something else 2'
+      },
+      {
+        name: 'children1-2',
+        parent: 13
+      },
+      {
+        name: 'parent2',
+        id: 14
+      },
+      {
+        name: 'something else 3'
+      },
+      {
+        name: 'children2-1',
+        parent: 14
+      }
+    ];
+
+    const expected = [
+      {
+        name: 'parent1',
+        id: 13
+      },
+      {
+        name: 'children1-1',
+        parent: 13
+      },
+      {
+        name: 'children1-2',
+        parent: 13
+      },
+      {
+        name: 'something else',
+        id: 1
+      },
+      {
+        name: 'something else 2'
+      },
+      {
+        name: 'parent2',
+        id: 14
+      },
+      {
+        name: 'children2-1',
+        parent: 14
+      },
+      {
+        name: 'something else 3'
+      }
+    ];
+
+    expect(fixOrder()(rowsWithMultipleParents)).toEqual(expected);
+  });
+
+  it('works with nested children', () => {
+    const rowsWithNestedChildren = [
+      {
+        name: 'something else'
+      },
+      {
+        id: 0,
+      },
+      {
+        name: 'something else2'
+      },
+      {
+        parent: 0,
+        id: 1
+      },
+      {
+        name: 'something else3'
+      },
+      {
+        parent: 1
+      },
+      {
+        name: 'something else4'
+      }
+    ];
+
+    const expectedOrder = [
+      {
+        name: 'something else'
+      },
+      {
+        id: 0,
+      },
+      {
+        parent: 0,
+        id: 1
+      },
+      {
+        parent: 1
+      },
+      {
+        name: 'something else2'
+      },
+      {
+        name: 'something else3'
+      },
+      {
+        name: 'something else4'
+      }
+    ];
+
+    expect(fixOrder()(rowsWithNestedChildren)).toEqual(expectedOrder);
+  });
+
+  it ('works with complex example', () => {
+    const complexRows = [
+      {
+        name: 'a'
+      },
+      {
+        id: 0
+      },
+      {
+        name: 'b'
+      },
+      {
+        parent: 0,
+        id: 1
+      },
+      {
+        name: 'c'
+      },
+      {
+        parent: 1,
+        id: 2
+      },
+      {
+        parent: 0
+      },
+      {
+        name: 'd'
+      },
+      {
+        parent: 2,
+        id: 3
+      },
+      {
+        name: 'e'
+      },
+      {
+        name: 'f'
+      },
+      {
+        parent: 1,
+        id: 4
+      },
+      {
+        name: 'g'
+      },
+      {
+        parent: 4
+      },
+      {
+        parent: 3
+      }
+    ];
+
+    const expectedRows = [
+      {
+        name: 'a'
+      },
+      {
+        id: 0
+      },
+      {
+        parent: 0,
+        id: 1
+      },
+      {
+        parent: 1,
+        id: 2
+      },
+      {
+        parent: 2,
+        id: 3
+      },
+      {
+        parent: 3
+      },
+      {
+        parent: 1,
+        id: 4
+      },
+      {
+        parent: 4
+      },
+      {
+        parent: 0
+      },
+      {
+        name: 'b'
+      },
+      {
+        name: 'c'
+      },
+
+      {
+        name: 'd'
+      },
+      {
+        name: 'e'
+      },
+      {
+        name: 'f'
+      },
+      {
+        name: 'g'
+      },
+    ];
+
+    expect(fixOrder()(complexRows)).toEqual(expectedRows);
+  });
+
+  it ('allows to have custom parent and id fields', () => {
+    const customFieldsRows = [
+      {
+        name: 'something'
+      },
+      {
+        my_id: 0
+      },
+      {
+        name: 'something else'
+      },
+      {
+        parent_id: 0
+      }
+    ];
+
+    const expected = [
+      {
+        name: 'something'
+      },
+      {
+        my_id: 0
+      },
+      {
+        parent_id: 0
+      },
+      {
+        name: 'something else'
+      },
+    ];
+
+    expect(fixOrder({
+      idField: 'my_id',
+      parentField: 'parent_id'
+    })(customFieldsRows)).toEqual(expected);
+  });
+
+  it('allows to use string ids', () => {
+    const stringIdsRows = [
+      {
+        id: 'a'
+      },
+      {
+        name: 'something else'
+      },
+      {
+        parent: 'a'
+      }
+    ];
+
+    const expected = [
+      {
+        id: 'a'
+      },
+      {
+        parent: 'a'
+      },
+      {
+        name: 'something else'
+      }
+    ];
+
+    expect(fixOrder()(stringIdsRows)).toEqual(expected);
+  });
+
+  it ('does not mutate parameter', () => {
+    const rowsWithWrongOrder = [
+      {
+        name: 'parent',
+        id: 13
+      },
+      {
+        name: 'another one'
+      },
+      {
+        name: 'children',
+        parent: 13
+      }
+    ];
+
+    const memo = cloneDeep(rowsWithWrongOrder);
+
+    fixOrder()(rowsWithWrongOrder);
+
+    expect(rowsWithWrongOrder).toEqual(memo);
+  });
+
+  it('works with reverse case', () => {
+    const reversedRows = [
+      {
+        parent: 3
+      },
+      {
+        id: 3,
+        parent: 2
+      },
+      {
+        id: 2,
+        parent: 1
+      },
+      {
+        id: 1
+      }
+    ];
+
+    expect(fixOrder()(reversedRows)).toEqual(reverse(reversedRows));
+  });
+});

--- a/__tests__/fix-order-test.js
+++ b/__tests__/fix-order-test.js
@@ -1,9 +1,7 @@
+import { cloneDeep, reverse } from 'lodash';
 import { fixOrder } from '../src';
 
-import { cloneDeep, reverse } from 'lodash';
-
 describe('fixOrder', () => {
-
   it('works with empty array', () => {
     expect(fixOrder()([])).toEqual([]);
   });
@@ -16,7 +14,7 @@ describe('fixOrder', () => {
     const dummyRows = [
       {
         name: 'A',
-        id:1
+        id: 1
       },
       {
         name: 'B',
@@ -27,7 +25,7 @@ describe('fixOrder', () => {
     expect(fixOrder()(dummyRows)).toEqual(dummyRows);
   });
 
-  it ('works with rows with children in right order', () => {
+  it('works with rows with children in right order', () => {
     const dummyRows = [
       {
         name: 'parent',
@@ -45,7 +43,7 @@ describe('fixOrder', () => {
     expect(fixOrder()(dummyRows)).toEqual(dummyRows);
   });
 
-  it ('works with simple case of wrong order', () => {
+  it('works with simple case of wrong order', () => {
     const rowsWithWrongOrder = [
       {
         name: 'parent',
@@ -78,7 +76,7 @@ describe('fixOrder', () => {
   });
 
 
-  it ('works when id is equal to zero', () => {
+  it('works when id is equal to zero', () => {
     const rowsWithWrongOrder = [
       {
         name: 'parent',
@@ -110,13 +108,13 @@ describe('fixOrder', () => {
       },
       {
         name: 'another one2'
-      },
+      }
     ];
 
     expect(fixOrder()(rowsWithWrongOrder)).toEqual(expectedRows);
   });
 
-  it ('works when parent is set to null', () => {
+  it('works when parent is set to null', () => {
     const rowsWithNullParent = [
       {
         name: 'something'
@@ -158,7 +156,7 @@ describe('fixOrder', () => {
     expect(fixOrder()(rowsWithNullParent)).toEqual(expected);
   });
 
-  it ('works when id set to null', () => {
+  it('works when id set to null', () => {
     const rowsWithIdNull = [
       {
         id: null
@@ -174,7 +172,7 @@ describe('fixOrder', () => {
     expect(fixOrder()(rowsWithIdNull)).toEqual(rowsWithIdNull);
   });
 
-  it ('works when parent id points to non existing element', () => {
+  it('works when parent id points to non existing element', () => {
     const rowsWithInvalidParentId = [
       {
         id: 2
@@ -189,7 +187,7 @@ describe('fixOrder', () => {
     expect(fixOrder()(rowsWithInvalidParentId)).toEqual(rowsWithInvalidParentId);
   });
 
-  it ('works with multiple parents', () => {
+  it('works with multiple parents', () => {
     const rowsWithMultipleParents = [
       {
         name: 'parent1',
@@ -265,7 +263,7 @@ describe('fixOrder', () => {
         name: 'something else'
       },
       {
-        id: 0,
+        id: 0
       },
       {
         name: 'something else2'
@@ -290,7 +288,7 @@ describe('fixOrder', () => {
         name: 'something else'
       },
       {
-        id: 0,
+        id: 0
       },
       {
         parent: 0,
@@ -313,7 +311,7 @@ describe('fixOrder', () => {
     expect(fixOrder()(rowsWithNestedChildren)).toEqual(expectedOrder);
   });
 
-  it ('works with complex example', () => {
+  it('works with complex example', () => {
     const complexRows = [
       {
         name: 'a'
@@ -416,13 +414,13 @@ describe('fixOrder', () => {
       },
       {
         name: 'g'
-      },
+      }
     ];
 
     expect(fixOrder()(complexRows)).toEqual(expectedRows);
   });
 
-  it ('allows to have custom parent and id fields', () => {
+  it('allows to have custom parent and id fields', () => {
     const customFieldsRows = [
       {
         name: 'something'
@@ -450,7 +448,7 @@ describe('fixOrder', () => {
       },
       {
         name: 'something else'
-      },
+      }
     ];
 
     expect(fixOrder({
@@ -487,7 +485,7 @@ describe('fixOrder', () => {
     expect(fixOrder()(stringIdsRows)).toEqual(expected);
   });
 
-  it ('does not mutate parameter', () => {
+  it('does not mutate parameter', () => {
     const rowsWithWrongOrder = [
       {
         name: 'parent',

--- a/src/fix-order.js
+++ b/src/fix-order.js
@@ -3,13 +3,13 @@ import _ from 'lodash';
 const fixOrder = ({
   idField = 'id',
   parentField = 'parent'
-} = {}) => rows => {
+} = {}) => (rows) => {
   if (_.isEmpty(rows)) {
     return rows;
   }
 
   // collect all IDs from rows so we can validate parent IDs
-  const existingIds = rows.reduce( (ids, row) => {
+  const existingIds = rows.reduce((ids, row) => {
     if (!_.isNil(row[idField])) {
       ids.push(row[idField]);
     }
@@ -18,10 +18,10 @@ const fixOrder = ({
 
   // collect all rows which are children,
   // meaning they have "parent" property and it points to existing row
-  const children = rows.filter(x => {
-   const hasParentId = !_.isNil(x[parentField]);
-   const parentExists = hasParentId && _.indexOf(existingIds, x[parentField]) !== -1;
-   return hasParentId && parentExists;
+  const children = rows.filter((x) => {
+    const hasParentId = !_.isNil(x[parentField]);
+    const parentExists = hasParentId && _.indexOf(existingIds, x[parentField]) !== -1;
+    return hasParentId && parentExists;
   });
 
   if (!children.length) {
@@ -37,10 +37,14 @@ const fixOrder = ({
   // into right place
   const rowsWithoutChildren = _.differenceWith(rows, children, _.isEqual);
 
-  _.forOwn(childrenPerParent, (children, parentId) => {
-    const parentPosition = _.findIndex(rowsWithoutChildren, (x) => parentId == x[idField]);
+  _.forOwn(childrenPerParent, (childrenFromParent, parentId) => {
+    const parentPosition = _.findIndex(rowsWithoutChildren, (x) => {
+      const hasId = !_.isNil(x[idField]);
+      const matchesParentId = hasId && (parentId === x[idField].toString());
+      return hasId && matchesParentId;
+    });
     // puts children right after their parent so correct order will be kept
-    rowsWithoutChildren.splice(parentPosition + 1, 0, ...children);
+    rowsWithoutChildren.splice(parentPosition + 1, 0, ...childrenFromParent);
   });
 
   return rowsWithoutChildren;

--- a/src/fix-order.js
+++ b/src/fix-order.js
@@ -1,0 +1,49 @@
+import _ from 'lodash';
+
+const fixOrder = ({
+  idField = 'id',
+  parentField = 'parent'
+} = {}) => rows => {
+  if (_.isEmpty(rows)) {
+    return rows;
+  }
+
+  // collect all IDs from rows so we can validate parent IDs
+  const existingIds = rows.reduce( (ids, row) => {
+    if (!_.isNil(row[idField])) {
+      ids.push(row[idField]);
+    }
+    return ids;
+  }, []);
+
+  // collect all rows which are children,
+  // meaning they have "parent" property and it points to existing row
+  const children = rows.filter(x => {
+   const hasParentId = !_.isNil(x[parentField]);
+   const parentExists = hasParentId && _.indexOf(existingIds, x[parentField]) !== -1;
+   return hasParentId && parentExists;
+  });
+
+  if (!children.length) {
+    return rows;
+  }
+
+  // groups all children per parent into a object,
+  // which looks like that:
+  // { parent_id1 : [children of parent id1], parent_id2: [... ] }
+  const childrenPerParent = _.groupBy(children, x => x[parentField]);
+
+  // removes all children from rows so we can start putting them
+  // into right place
+  const rowsWithoutChildren = _.differenceWith(rows, children, _.isEqual);
+
+  _.forOwn(childrenPerParent, (children, parentId) => {
+    const parentPosition = _.findIndex(rowsWithoutChildren, (x) => parentId == x[idField]);
+    // puts children right after their parent so correct order will be kept
+    rowsWithoutChildren.splice(parentPosition + 1, 0, ...children);
+  });
+
+  return rowsWithoutChildren;
+};
+
+export default fixOrder;

--- a/src/index.js
+++ b/src/index.js
@@ -12,3 +12,4 @@ export { default as search } from './search';
 export { default as toggleChildren } from './toggle-children';
 export { default as collapseAll } from './collapse-all';
 export { default as expandAll } from './expand-all';
+export { default as fixOrder } from './fix-order';


### PR DESCRIPTION
Added `fixOrder` helper method which fixes cases when children don't follow their parents.
Basically it converts this:
`[parentA, xyz..., children-of-parentA]`
into: 
`[parentA, children-of-parentA, xyz...]`.

Usage: `fixOrder()(rows)` or `fixOrder({ idField, parentField})(rows)`.