### PR TITLE
fixed toggleChildren method doesn't render css correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,13 +53,13 @@ Collapses rows by setting `showingChildren` of each row to `false`.
 
 Expands rows by setting `showingChildren` of each row to `true`.
 
-**`tree.filter = ({ fieldName, parentField = 'parent' }) => (rows) => [<filteredRow>]`**
+**`tree.filter = ({ fieldName, idField = 'parentId', parentField = 'parent' }) => (rows) => [<filteredRow>]`**
 
 Filters the given rows using `fieldName`. This is handy if you want only rows that are visible assuming visibility logic has been defined.
 
 ### Queries
 
-**`tree.getLevel = ({ index, parentField = 'parent' }) => (rows) => <level>`**
+**`tree.getLevel = ({ index, idField = 'parentId', parentField = 'parent' }) => (rows) => <level>`**
 
 Returns the nesting level of the row at the given `index` within `rows`.
 
@@ -71,7 +71,7 @@ Returns children based on given `rows` and `index`. This includes children of ch
 
 Returns immediate children based on given `rows` and `index`.
 
-**`tree.getParents = ({ index, parentField = 'parent' }) => (rows) => [<parent>]`**
+**`tree.getParents = ({ index, idField = 'parentId', parentField = 'parent' }) => (rows) => [<parent>]`**
 
 Returns parents based on given `rows` and `index`.
 
@@ -121,7 +121,7 @@ Allows moving tree rows while `retain`ing given fields at their original rows. Y
 
 ### UI
 
-**`tree.toggleChildren = ({ getRows, getShowingChildren, toggleShowingChildren, props, idField, parentField }) => (value, extra) => <React element>`**
+**`tree.toggleChildren = ({ getRows, getShowingChildren, toggleShowingChildren, props, idField = 'id', parentField }) => (value, extra) => <React element>`**
 
 Makes it possible to toggle node children through a user interface.
 

--- a/__tests__/get-level-test.js
+++ b/__tests__/get-level-test.js
@@ -22,13 +22,13 @@ describe('tree.getLevel', function () {
         foo: 'bar'
       },
       {
-        parent: 'baz',
+        parent: 'bar',
         foo: 'foo'
       }
     ];
     const expected = 1;
 
-    expect(getLevel({ index: 1 })(given)).toEqual(expected);
+    expect(getLevel({ index: 1, idField: 'foo' })(given)).toEqual(expected);
   });
 
   it('returns one if there is one parent and parent has null parent', function () {
@@ -38,13 +38,13 @@ describe('tree.getLevel', function () {
         foo: 'bar'
       },
       {
-        parent: 'baz',
+        parent: 'bar',
         foo: 'foo'
       }
     ];
     const expected = 1;
 
-    expect(getLevel({ index: 1 })(given)).toEqual(expected);
+    expect(getLevel({ index: 1, idField: 'foo' })(given)).toEqual(expected);
   });
 
   it('works with sibling children', function () {
@@ -53,17 +53,17 @@ describe('tree.getLevel', function () {
         foo: 'bar'
       },
       {
-        parent: 'baz',
+        parent: 'bar',
         foo: 'foo'
       },
       {
-        parent: 'baz',
+        parent: 'bar',
         foo: 'barbar'
       }
     ];
     const expected = 1;
 
-    expect(getLevel({ index: 2 })(given)).toEqual(expected);
+    expect(getLevel({ index: 2, idField: 'foo' })(given)).toEqual(expected);
   });
 
   it('works with preceding parent', function () {
@@ -72,7 +72,7 @@ describe('tree.getLevel', function () {
         foo: 'bar'
       },
       {
-        parent: 'baz',
+        parent: 'bar',
         foo: 'foo'
       },
       {
@@ -81,7 +81,7 @@ describe('tree.getLevel', function () {
     ];
     const expected = 0;
 
-    expect(getLevel({ index: 2 })(given)).toEqual(expected);
+    expect(getLevel({ index: 2, idField: 'foo' })(given)).toEqual(expected);
   });
 
   it('works with preceding parent if own parent is null', function () {
@@ -90,7 +90,7 @@ describe('tree.getLevel', function () {
         foo: 'bar'
       },
       {
-        parent: 'baz',
+        parent: 'bar',
         foo: 'foo'
       },
       {
@@ -100,7 +100,7 @@ describe('tree.getLevel', function () {
     ];
     const expected = 0;
 
-    expect(getLevel({ index: 2 })(given)).toEqual(expected);
+    expect(getLevel({ index: 2, idField: 'foo' })(given)).toEqual(expected);
   });
 
   it('works with sibling children without parents', function () {
@@ -114,7 +114,7 @@ describe('tree.getLevel', function () {
     ];
     const expected = 0;
 
-    expect(getLevel({ index: 1 })(given)).toEqual(expected);
+    expect(getLevel({ index: 1, idField: 'foo' })(given)).toEqual(expected);
   });
 
   it('works with sibling children when parent is set to null', function () {
@@ -130,7 +130,7 @@ describe('tree.getLevel', function () {
     ];
     const expected = 0;
 
-    expect(getLevel({ index: 1 })(given)).toEqual(expected);
+    expect(getLevel({ index: 1, idField: 'foo' })(given)).toEqual(expected);
   });
 
   it('works with nested children', function () {
@@ -139,7 +139,7 @@ describe('tree.getLevel', function () {
         foo: 'bar'
       },
       {
-        parent: 'baz',
+        parent: 'bar',
         foo: 'foo'
       },
       {
@@ -149,7 +149,7 @@ describe('tree.getLevel', function () {
     ];
     const expected = 2;
 
-    expect(getLevel({ index: 2 })(given)).toEqual(expected);
+    expect(getLevel({ index: 2, idField: 'foo' })(given)).toEqual(expected);
   });
 
   it('allows parent field to be customized', function () {
@@ -159,7 +159,7 @@ describe('tree.getLevel', function () {
         foo: 'bar'
       },
       {
-        [parentField]: 'baz',
+        [parentField]: 'bar',
         foo: 'foo'
       },
       {
@@ -169,6 +169,6 @@ describe('tree.getLevel', function () {
     ];
     const expected = 2;
 
-    expect(getLevel({ index: 2, parentField })(given)).toEqual(expected);
+    expect(getLevel({ index: 2, idField: 'foo', parentField })(given)).toEqual(expected);
   });
 });

--- a/__tests__/get-parents-test.js
+++ b/__tests__/get-parents-test.js
@@ -16,13 +16,29 @@ describe('tree.getParents', function () {
     expect(getParents({ index: 0 })(given)).toEqual(expected);
   });
 
+  it('returns an empty array if there are no matching parents', function () {
+    const given = [
+      {
+        parent: null,
+        foo: 'bar'
+      },
+      {
+        parent: 'baz',
+        foo: 'foo'
+      }
+    ];
+    const expected = [];
+
+    expect(getParents({ index: 1, idField: 'foo' })(given)).toEqual(expected);
+  });
+
   it('returns an array with parent if there is one parent', function () {
     const given = [
       {
         foo: 'bar'
       },
       {
-        parent: 'baz',
+        parent: 'bar',
         foo: 'foo'
       }
     ];
@@ -32,7 +48,7 @@ describe('tree.getParents', function () {
       }
     ];
 
-    expect(getParents({ index: 1 })(given)).toEqual(expected);
+    expect(getParents({ index: 1, idField: 'foo' })(given)).toEqual(expected);
   });
 
   it('returns an array with parent if there is one parent and parent has null parent', function () {
@@ -42,7 +58,7 @@ describe('tree.getParents', function () {
         foo: 'bar'
       },
       {
-        parent: 'baz',
+        parent: 'bar',
         foo: 'foo'
       }
     ];
@@ -53,7 +69,7 @@ describe('tree.getParents', function () {
       }
     ];
 
-    expect(getParents({ index: 1 })(given)).toEqual(expected);
+    expect(getParents({ index: 1, idField: 'foo' })(given)).toEqual(expected);
   });
 
   it('works with sibling children', function () {
@@ -62,11 +78,11 @@ describe('tree.getParents', function () {
         foo: 'bar'
       },
       {
-        parent: 'baz',
+        parent: 'bar',
         foo: 'foo'
       },
       {
-        parent: 'baz',
+        parent: 'bar',
         foo: 'barbar'
       }
     ];
@@ -76,7 +92,7 @@ describe('tree.getParents', function () {
       }
     ];
 
-    expect(getParents({ index: 2 })(given)).toEqual(expected);
+    expect(getParents({ index: 2, idField: 'foo' })(given)).toEqual(expected);
   });
 
   it('works with preceding parent', function () {
@@ -85,7 +101,7 @@ describe('tree.getParents', function () {
         foo: 'bar'
       },
       {
-        parent: 'baz',
+        parent: 'bar',
         foo: 'foo'
       },
       {
@@ -94,7 +110,7 @@ describe('tree.getParents', function () {
     ];
     const expected = [];
 
-    expect(getParents({ index: 2 })(given)).toEqual(expected);
+    expect(getParents({ index: 2, idField: 'foo' })(given)).toEqual(expected);
   });
 
   it('works with preceding parent if own parent is null', function () {
@@ -103,7 +119,7 @@ describe('tree.getParents', function () {
         foo: 'bar'
       },
       {
-        parent: 'baz',
+        parent: 'bar',
         foo: 'foo'
       },
       {
@@ -113,7 +129,7 @@ describe('tree.getParents', function () {
     ];
     const expected = [];
 
-    expect(getParents({ index: 2 })(given)).toEqual(expected);
+    expect(getParents({ index: 2, idField: 'foo' })(given)).toEqual(expected);
   });
 
   it('works with sibling children without parents', function () {
@@ -127,7 +143,7 @@ describe('tree.getParents', function () {
     ];
     const expected = [];
 
-    expect(getParents({ index: 1 })(given)).toEqual(expected);
+    expect(getParents({ index: 1, idField: 'foo' })(given)).toEqual(expected);
   });
 
   it('works with sibling children when parent is set to null', function () {
@@ -152,7 +168,7 @@ describe('tree.getParents', function () {
         foo: 'bar'
       },
       {
-        parent: 'baz',
+        parent: 'bar',
         foo: 'foo'
       },
       {
@@ -165,12 +181,12 @@ describe('tree.getParents', function () {
         foo: 'bar'
       },
       {
-        parent: 'baz',
+        parent: 'bar',
         foo: 'foo'
       }
     ];
 
-    expect(getParents({ index: 2 })(given)).toEqual(expected);
+    expect(getParents({ index: 2, idField: 'foo' })(given)).toEqual(expected);
   });
 
   it('allows parent field to be customized', function () {
@@ -180,7 +196,7 @@ describe('tree.getParents', function () {
         foo: 'bar'
       },
       {
-        [parentField]: 'baz',
+        [parentField]: 'bar',
         foo: 'foo'
       },
       {
@@ -193,11 +209,11 @@ describe('tree.getParents', function () {
         foo: 'bar'
       },
       {
-        [parentField]: 'baz',
+        [parentField]: 'bar',
         foo: 'foo'
       }
     ];
 
-    expect(getParents({ index: 2, parentField })(given)).toEqual(expected);
+    expect(getParents({ index: 2, idField: 'foo', parentField })(given)).toEqual(expected);
   });
 });

--- a/__tests__/toggle-children-test.js
+++ b/__tests__/toggle-children-test.js
@@ -1,44 +1,43 @@
 import { cloneDeep } from 'lodash';
-import React from 'react';
-
 import { toggleChildren } from '../src';
+
 const dummyRows = [
   {
-    "id": "MNU00900",
-    "parent": null,
-    "name": "Configuration",
+    id: 'MNU00900',
+    parent: null,
+    name: 'Configuration'
   },
   {
-    "id": "MNU00901",
-    "parent": "MNU00900",
-    "name": "UserMangement",
+    id: 'MNU00901',
+    parent: 'MNU00900',
+    name: 'UserMangement'
   },
   {
-    "id": "MNU00902",
-    "parent": "MNU00900",
-    "name": "MenuMangement",
+    id: 'MNU00902',
+    parent: 'MNU00900',
+    name: 'MenuMangement'
   },
   {
-    "id": "MNU00904",
-    "parent": "MNU00902",
-    "name": "TEST",
+    id: 'MNU00904',
+    parent: 'MNU00902',
+    name: 'TEST'
   },
   {
-    "id": "MNU00803",
-    "parent": "MNU00900",
-    "name": "RoleMangement",
+    id: 'MNU00803',
+    parent: 'MNU00900',
+    name: 'RoleMangement'
   },
   {
-    "id": "MNU00905",
-    "parent": "MNU00803",
-    "name": "TEST",
+    id: 'MNU00905',
+    parent: 'MNU00803',
+    name: 'TEST'
   }
 ];
 
 const initializer = {
   getRows: () => dummyRows,
   getShowingChildren: ({ rowData }) => rowData.showingChildren,
-  toggleShowingChildren: rowIndex => {
+  toggleShowingChildren: (rowIndex) => {
     const rows = cloneDeep(dummyRows);
     rows[rowIndex].showingChildren = !rows[rowIndex].showingChildren;
   },
@@ -53,7 +52,7 @@ describe('tree.toggleChildren', function () {
       rowIndex: 0,
       rowData: {
         _index: 0,
-        id: "MNU00900",
+        id: 'MNU00900',
         parentId: null
       }
     };
@@ -67,7 +66,7 @@ describe('tree.toggleChildren', function () {
       rowIndex: 0,
       rowData: {
         _index: 0,
-        id: "MNU00900",
+        id: 'MNU00900',
         parentId: null
       }
     };
@@ -83,7 +82,7 @@ describe('tree.toggleChildren', function () {
       rowIndex: 0,
       rowData: {
         _index: 0,
-        id: "MNU00900",
+        id: 'MNU00900',
         parentId: null
       }
     };
@@ -94,14 +93,18 @@ describe('tree.toggleChildren', function () {
   });
 
   it('throw missing getRows error if it missed', function () {
-    expect(toggleChildren.bind(null, {getShowingChildren: ()=>{}, toggleShowingChildren: ()=>{}})).toThrow(Error);
+    expect(toggleChildren
+      .bind(null, { getShowingChildren: () => {}, toggleShowingChildren: () => {} }))
+      .toThrow(Error);
   });
 
   it('throw missing getShowingChildren error if it missed', function () {
-    expect(toggleChildren.bind(null, {getRows: ()=>{}, toggleShowingChildren: ()=>{}})).toThrow(Error);
+    expect(toggleChildren.bind(null, { getRows: () => {}, toggleShowingChildren: () => {} }))
+      .toThrow(Error);
   });
 
   it('throw missing toggleShowingChildren error if it missed', function () {
-    expect(toggleChildren.bind(null, {getRows: ()=>{}, getShowingChildren: ()=>{}})).toThrow(Error);
+    expect(toggleChildren.bind(null, { getRows: () => {}, getShowingChildren: () => {} }))
+      .toThrow(Error);
   });
 });

--- a/__tests__/toggle-children-test.js
+++ b/__tests__/toggle-children-test.js
@@ -1,0 +1,107 @@
+import { cloneDeep } from 'lodash';
+import React from 'react';
+
+import { toggleChildren } from '../src';
+const dummyRows = [
+  {
+    "id": "MNU00900",
+    "parent": null,
+    "name": "Configuration",
+  },
+  {
+    "id": "MNU00901",
+    "parent": "MNU00900",
+    "name": "UserMangement",
+  },
+  {
+    "id": "MNU00902",
+    "parent": "MNU00900",
+    "name": "MenuMangement",
+  },
+  {
+    "id": "MNU00904",
+    "parent": "MNU00902",
+    "name": "TEST",
+  },
+  {
+    "id": "MNU00803",
+    "parent": "MNU00900",
+    "name": "RoleMangement",
+  },
+  {
+    "id": "MNU00905",
+    "parent": "MNU00803",
+    "name": "TEST",
+  }
+];
+
+const initializer = {
+  getRows: () => dummyRows,
+  getShowingChildren: ({ rowData }) => rowData.showingChildren,
+  toggleShowingChildren: rowIndex => {
+    const rows = cloneDeep(dummyRows);
+    rows[rowIndex].showingChildren = !rows[rowIndex].showingChildren;
+  },
+  // Inject custom class name per row here etc.
+  props: {}
+};
+
+describe('tree.toggleChildren', function () {
+  it('returns an root item', function () {
+    const value = 'MNU00900';
+    const extra = {
+      rowIndex: 0,
+      rowData: {
+        _index: 0,
+        id: "MNU00900",
+        parentId: null
+      }
+    };
+
+    expect(toggleChildren(initializer)(value, extra)).toMatchSnapshot();
+  });
+
+  it('double clicking root item works fine', function () {
+    const value = 'MNU00900';
+    const extra = {
+      rowIndex: 0,
+      rowData: {
+        _index: 0,
+        id: "MNU00900",
+        parentId: null
+      }
+    };
+    const tree = toggleChildren(initializer)(value, extra);
+    tree.props.onDoubleClick(new Event('ondblclick'));
+
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('clicking root tree indicator works fine', function () {
+    const value = 'MNU00900';
+    const extra = {
+      rowIndex: 0,
+      rowData: {
+        _index: 0,
+        id: "MNU00900",
+        parentId: null
+      }
+    };
+    const tree = toggleChildren(initializer)(value, extra);
+    const span = tree.props.children[0];
+    span.props.onClick(new Event('onclick'));
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('throw missing getRows error if it missed', function () {
+    expect(toggleChildren.bind(null, {getShowingChildren: ()=>{}, toggleShowingChildren: ()=>{}})).toThrow(Error);
+  });
+
+  it('throw missing getShowingChildren error if it missed', function () {
+    expect(toggleChildren.bind(null, {getRows: ()=>{}, toggleShowingChildren: ()=>{}})).toThrow(Error);
+  });
+
+  it('throw missing toggleShowingChildren error if it missed', function () {
+    expect(toggleChildren.bind(null, {getRows: ()=>{}, getShowingChildren: ()=>{}})).toThrow(Error);
+  });
+});

--- a/src/filter.js
+++ b/src/filter.js
@@ -2,6 +2,7 @@ import getParents from './get-parents';
 
 const filterTree = ({
   fieldName,
+  idField = 'id',
   parentField = 'parent'
 } = {}) => (rows) => {
   if (!fieldName) {
@@ -13,7 +14,7 @@ const filterTree = ({
       return true;
     }
 
-    const parents = getParents({ index, parentField })(rows);
+    const parents = getParents({ index, idField, parentField })(rows);
 
     return parents.filter(
       parent => parent[fieldName]

--- a/src/get-level.js
+++ b/src/get-level.js
@@ -2,9 +2,10 @@ import getParents from './get-parents';
 
 const getLevel = ({
   index,
+  idField = 'id',
   parentField = 'parent'
 } = {}) => rows => (
-  getParents({ index, parentField })(rows).length
+  getParents({ index, idField, parentField })(rows).length
 );
 
 export default getLevel;

--- a/src/get-parents.js
+++ b/src/get-parents.js
@@ -16,14 +16,11 @@ function getParents({
     }
 
     while (cell) {
-
       if (typeof searchingParent === 'undefined') {
         searchingParent = cell[parentField];
-      } else {
-        if (searchingParent === cell[idField]) {
-          parents.unshift(cell);
-          searchingParent = cell[parentField];
-        }
+      } else if (searchingParent === cell[idField]) {
+        parents.unshift(cell);
+        searchingParent = cell[parentField];
       }
 
       if (cell[parentField] === null) {

--- a/src/get-parents.js
+++ b/src/get-parents.js
@@ -1,44 +1,36 @@
+import _ from 'lodash';
+
 function getParents({
   index,
+  idField = 'id',
   parentField = 'parent'
 } = {}) {
   return (rows) => {
     const parents = [];
     let currentIndex = index;
     let cell = rows[index];
-    let previousParent;
+    let searchingParent;
 
-    if (
-      !cell ||
-      typeof cell[parentField] === 'undefined' ||
-      cell[parentField] === null
-    ) {
+    if (!cell || _.isNil(cell[parentField])) {
       return parents;
     }
 
     while (cell) {
-      if (cell[parentField] === null) {
-        if (previousParent !== cell[parentField]) {
-          parents.unshift(cell);
-        }
 
-        break;
-      }
-      if (typeof cell[parentField] !== 'undefined') {
-        if (typeof previousParent !== 'undefined' && previousParent !== cell[parentField]) {
-          parents.unshift(cell);
-        }
+      if (typeof searchingParent === 'undefined') {
+        searchingParent = cell[parentField];
       } else {
-        if (typeof previousParent !== 'undefined') {
+        if (searchingParent === cell[idField]) {
           parents.unshift(cell);
+          searchingParent = cell[parentField];
         }
+      }
 
+      if (cell[parentField] === null) {
         break;
       }
 
       currentIndex -= 1;
-
-      previousParent = cell[parentField];
       cell = rows[currentIndex];
     }
 

--- a/src/search.js
+++ b/src/search.js
@@ -26,7 +26,7 @@ function searchTree({
         fetchedParents[rowParent] = true;
 
         const children = getChildren({ index: row._index, idField, parentField })(rows);
-        const parents = getParents({ index: row._index, parentField })(rows);
+        const parents = getParents({ index: row._index, idField, parentField })(rows);
 
         return parents.concat(row).concat(children);
       }).filter(a => a)

--- a/src/toggle-children.js
+++ b/src/toggle-children.js
@@ -35,7 +35,7 @@ const toggleChildren = ({
     const rows = getRows();
     const showingChildren = getShowingChildren(extra);
     const index = rowData._index;
-    const containsChildren = hasChildren({ index, idField })(rows) ? 'has-children' : '';
+    const containsChildren = hasChildren({ index, idField, parentField })(rows) ? 'has-children' : '';
     const level = getLevel({ index, parentField })(rows);
     const hasParent = level > 0 ? 'has-parent' : '';
 

--- a/src/toggle-children.js
+++ b/src/toggle-children.js
@@ -46,7 +46,7 @@ const toggleChildren = ({
         // since toggling with a click makes it difficult to select each item.
         onDoubleClick={e => {
           toggle(e, index);
-          window.getSelection().removeAllRanges();
+          window.getSelection && window.getSelection().removeAllRanges();
         }}
         className={`${containsChildren} ${hasParent} ${className || ''}`}
         {...restProps}

--- a/src/toggle-children.js
+++ b/src/toggle-children.js
@@ -7,7 +7,7 @@ const toggleChildren = ({
   getShowingChildren,
   toggleShowingChildren,
   props,
-  idField,
+  idField = 'id',
   parentField
 } = {}) => {
   if (!getRows) {
@@ -31,18 +31,23 @@ const toggleChildren = ({
 
   return (value, extra) => {
     const { className, ...restProps } = props || {}; // eslint-disable-line react/prop-types
-    const { rowData } = extra;
     const rows = getRows();
     const showingChildren = getShowingChildren(extra);
-    const index = rowData._index;
+    // index must be the index of original rows, but filtered rows
+    const index = rows.findIndex(row => row[idField] === value);
     const containsChildren = hasChildren({ index, idField, parentField })(rows) ? 'has-children' : '';
-    const level = getLevel({ index, parentField })(rows);
+    const level = getLevel({ index, idField, parentField })(rows);
     const hasParent = level > 0 ? 'has-parent' : '';
 
     return (
       <div
         style={{ paddingLeft: `${level}em` }}
-        onClick={e => toggle(e, index)}
+        // toggling children with a doubleClick would provide better UX
+        // since toggling with a click makes it difficult to select each item.
+        onDoubleClick={e => {
+          toggle(e, index);
+          window.getSelection().removeAllRanges();
+        }}
         className={`${containsChildren} ${hasParent} ${className || ''}`}
         {...restProps}
       >

--- a/src/toggle-children.js
+++ b/src/toggle-children.js
@@ -44,7 +44,7 @@ const toggleChildren = ({
         style={{ paddingLeft: `${level}em` }}
         // toggling children with a doubleClick would provide better UX
         // since toggling with a click makes it difficult to select each item.
-        onDoubleClick={e => {
+        onDoubleClick={(e) => {
           toggle(e, index);
           window.getSelection && window.getSelection().removeAllRanges();
         }}


### PR DESCRIPTION
Since `toggleChildren` doesn't pass `parentField` to `hasChildren` method, className is not decided correctly.

It fixed by passing `parentField` to `hasChildren` method.
