### PR TITLE
Added option to disable automatic indentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,8 @@ Allows moving tree rows while `retain`ing given fields at their original rows. Y
 
 **`tree.toggleChildren = ({ getIndex, getRows, getShowingChildren, toggleShowingChildren, props, idField = 'id', parentField }) => (value, extra) => <React element>`**
 
-Makes it possible to toggle node children through a user interface.
+Makes it possible to toggle node children through a user interface.  
+Pass `"indent":false` inside `props` object if you want to disable automatic indentation.
 
 The default implementation of `getIndex(rowData)` depends on [resolve.resolve](https://www.npmjs.com/package/table-resolver#resolveresolve) as it looks for index of the row to toggle based on that. This can be customized through.
 

--- a/__tests__/toggle-children-configuration-test.js
+++ b/__tests__/toggle-children-configuration-test.js
@@ -1,0 +1,61 @@
+/**
+ * Created by piotr on 23/02/17.
+ */
+import {cloneDeep} from 'lodash';
+import {toggleChildren} from '../src';
+
+const dummyRows = [
+  {
+    id: '0',
+    parent: null
+  },
+  {
+    id: '1',
+    parent: '0'
+  },
+  {
+    id: '2',
+    parent: '1'
+  }
+];
+
+const initializerWithAutomaticIndentation = {
+  getRows: () => dummyRows,
+  getShowingChildren: ({rowData}) => rowData.showingChildren,
+  toggleShowingChildren: (rowIndex) => {
+    const rows = cloneDeep(dummyRows);
+    rows[rowIndex].showingChildren = !rows[rowIndex].showingChildren;
+  },
+  props: {}
+};
+
+const initializerWithoutAutomaticIndentation = {
+  ...initializerWithAutomaticIndentation,
+  props: {
+    automaticIndentation: false
+  }
+};
+
+describe('tree.toggleChildren configuration', function () {
+
+  let rowValue = '2';
+  let rowExtraInfo = {
+    rowData: {
+      _index: 2,
+    }
+  };
+
+  it('supports automatic indentation', () => {
+    const toggled = toggleChildren(initializerWithAutomaticIndentation)(rowValue, rowExtraInfo);
+    const {style} = toggled.props;
+
+    expect(style.paddingLeft).toBeDefined();
+  });
+
+  it('supports disabling automatic indentation', () => {
+    const toggled = toggleChildren(initializerWithoutAutomaticIndentation)(rowValue, rowExtraInfo);
+    const {style} = toggled.props;
+
+    expect(style.paddingLeft).not.toBeDefined();
+  });
+});

--- a/__tests__/toggle-children-configuration-test.js
+++ b/__tests__/toggle-children-configuration-test.js
@@ -32,7 +32,7 @@ const initializerWithAutomaticIndentation = {
 const initializerWithoutAutomaticIndentation = {
   ...initializerWithAutomaticIndentation,
   props: {
-    automaticIndentation: false
+    indent: false
   }
 };
 

--- a/__tests__/toggle-children-configuration-test.js
+++ b/__tests__/toggle-children-configuration-test.js
@@ -1,8 +1,8 @@
 /**
  * Created by piotr on 23/02/17.
  */
-import {cloneDeep} from 'lodash';
-import {toggleChildren} from '../src';
+import { cloneDeep } from 'lodash';
+import { toggleChildren } from '../src';
 
 const dummyRows = [
   {
@@ -21,7 +21,7 @@ const dummyRows = [
 
 const initializerWithAutomaticIndentation = {
   getRows: () => dummyRows,
-  getShowingChildren: ({rowData}) => rowData.showingChildren,
+  getShowingChildren: ({ rowData }) => rowData.showingChildren,
   toggleShowingChildren: (rowIndex) => {
     const rows = cloneDeep(dummyRows);
     rows[rowIndex].showingChildren = !rows[rowIndex].showingChildren;
@@ -37,24 +37,23 @@ const initializerWithoutAutomaticIndentation = {
 };
 
 describe('tree.toggleChildren configuration', function () {
-
-  let rowValue = '2';
-  let rowExtraInfo = {
+  const rowValue = '2';
+  const rowExtraInfo = {
     rowData: {
-      _index: 2,
+      _index: 2
     }
   };
 
   it('supports automatic indentation', () => {
     const toggled = toggleChildren(initializerWithAutomaticIndentation)(rowValue, rowExtraInfo);
-    const {style} = toggled.props;
+    const { style } = toggled.props;
 
     expect(style.paddingLeft).toBeDefined();
   });
 
   it('supports disabling automatic indentation', () => {
     const toggled = toggleChildren(initializerWithoutAutomaticIndentation)(rowValue, rowExtraInfo);
-    const {style} = toggled.props;
+    const { style } = toggled.props;
 
     expect(style.paddingLeft).not.toBeDefined();
   });

--- a/src/toggle-children.js
+++ b/src/toggle-children.js
@@ -1,7 +1,7 @@
 import React from 'react';
+import { get } from 'lodash';
 import getLevel from './get-level';
 import hasChildren from './has-children';
-import {get} from 'lodash';
 
 const toggleChildren = ({
   getIndex = rowData => rowData._index, // Look for index based on convention

--- a/src/toggle-children.js
+++ b/src/toggle-children.js
@@ -40,7 +40,7 @@ const toggleChildren = ({
     const level = getLevel({ index, idField, parentField })(rows);
     const hasParent = level > 0 ? 'has-parent' : '';
 
-    const hasAutomaticIndentation = get(props, 'automaticIndentation', true);
+    const hasAutomaticIndentation = get(props, 'indent', true);
 
     return (
       <div

--- a/src/toggle-children.js
+++ b/src/toggle-children.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import getLevel from './get-level';
 import hasChildren from './has-children';
+import {get} from 'lodash';
 
 const toggleChildren = ({
   getIndex = rowData => rowData._index, // Look for index based on convention
@@ -39,9 +40,11 @@ const toggleChildren = ({
     const level = getLevel({ index, idField, parentField })(rows);
     const hasParent = level > 0 ? 'has-parent' : '';
 
+    const hasAutomaticIndentation = get(props, 'automaticIndentation', true);
+
     return (
       <div
-        style={{ paddingLeft: `${level}em` }}
+        style={!!hasAutomaticIndentation && { paddingLeft: `${level}em` }}
         // toggling children with a doubleClick would provide better UX
         // since toggling with a click makes it difficult to select each item.
         onDoubleClick={(e) => {


### PR DESCRIPTION
By default, children rows get `{children-level} * em` padding from the left.
Users might either want to disable it at all or use custom styling.