### PR TITLE
fix jsx error when indent is false

### DIFF
--- a/src/toggle-children.js
+++ b/src/toggle-children.js
@@ -52,9 +52,11 @@ const toggleChildren = ({
       }
     };
 
+    const style = hasAutomaticIndentation ? { paddingLeft: `${level}em` } : {};
+
     return (
       <div
-        style={!!hasAutomaticIndentation && { paddingLeft: `${level}em` }}
+        style={style}
         className={`${containsChildren} ${hasParent} ${className || ''}`}
         {...events}
         {...restProps}


### PR DESCRIPTION
Fixes this issue that is thrown if the `ident` prop is set to false in the `toggleChildren` formatter:

```
Unhandled promise rejection Invariant Violation: "The `style` prop expects a mapping from style properties to values, not a string. For example, style={{marginRight: spacing + 'em'}} when using JSX.
```