### PR TITLE
filter performance improvement

### DIFF
--- a/__tests__/filter-test.js
+++ b/__tests__/filter-test.js
@@ -33,6 +33,11 @@ describe('tree.filter', function () {
         id: 234,
         parent: 123,
         foo: 'foo'
+      },
+      {
+        id: 567,
+        parent: 123,
+        foo: 'foo2'
       }
     ];
     const expected = [

--- a/src/filter.js
+++ b/src/filter.js
@@ -9,16 +9,30 @@ const filterTree = ({
     throw new Error('tree.filterTree - Missing fieldName!');
   }
 
+  // build up a cache of parent ids and whether their child rows should show
+  // to reduce the amount of lookups for performance
+  const parentCache = {};
+
   return rows.filter((row, index) => {
     if (typeof row[parentField] === 'undefined' || row[parentField] === null) {
       return true;
     }
 
+    const parentVal = parentCache[row[parentField]];
+    if (parentVal === false || parentVal === true) {
+      return parentVal;
+    }
+
     const parents = getParents({ index, idField, parentField })(rows);
 
-    return parents.filter(
+    // if all the rows parents are showing then we know that the row should should
+    const rowShouldShow = parents.filter(
       parent => parent[fieldName]
     ).length === parents.length;
+
+    parentCache[row[parentField]] = rowShouldShow;
+
+    return rowShouldShow;
   });
 };
 


### PR DESCRIPTION
The filter function performs poorly in IE11 when there are lots of rows.
This improvement means we don't need to perform the getParents on every child.

Example:

Before: 
When clicking on the expand/collapse button it takes about 5 seconds to update

![before](https://user-images.githubusercontent.com/14863246/66202425-a391b500-e69d-11e9-808f-9ceef958077a.gif)

After:
Is now pretty instant

![after](https://user-images.githubusercontent.com/14863246/66202440-aa202c80-e69d-11e9-9e4d-4dda3f030eba.gif)